### PR TITLE
Fix links to pages.

### DIFF
--- a/Breads/NavajoFryBread.xml
+++ b/Breads/NavajoFryBread.xml
@@ -38,7 +38,7 @@
 	</Instructions>
 
 	<Notes id="Notes">
-		<note>Eating it plain isn't very pleasurable, so make sure to have Honey, Butter, <a href="../Sauces/HoneyButter.xml">Sauces: Honey Butter</a>, Jam or something similar on hand.</note>
+		<note>Eating it plain isn't very pleasurable, so make sure to have <a href=".../Sauces/HoneyButter.xml">Sauces: Honey Butter</a>, Honey, Butter, Jam or something similar on hand.</note>
 		<note>For "Navajo Tacos" make regular taco fillings, but substitute these for the tortillas.</note>
 	</Notes>
 </Recipe>

--- a/Breads/UtahScones.xml
+++ b/Breads/UtahScones.xml
@@ -46,6 +46,6 @@
 	</Instructions>
 
 	<Notes id="Notes">
-		<note>To eat a Utah Scone, you should make a slit on one end, then put in <a href="../Sauces/HoneyButter.xml">Sauces: Honey Butter</a>!<br /><span class="NOTE">(or Honey, Butter, Jam, or something similar.)</span></note>
+		<note>To eat a Utah Scone, you should make a slit on one end, then put in <a href=".../Sauces/HoneyButter.xml">Sauces: Honey Butter</a>!<br /><span class="NOTE">(or Honey, Butter, Jam, or something similar.)</span></note>
 	</Notes>
 </Recipe>

--- a/Camping/Entrees/DO_BBQSpareRibs.xml
+++ b/Camping/Entrees/DO_BBQSpareRibs.xml
@@ -57,5 +57,5 @@
 		<note>When serving the ribs, the extra sauce tastes wonderful over baked potatoes, with a dollop of sour cream.</note>
 	</Notes>
 
-	<FinalNote id="FinalNote">A similar recipe for use at home: <a href="../../Entrees/CrockPot/BBQSpareRibs.xml">Entrees / CrockPot: BBQ Spare Ribs</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for use at home: <a href=".../Entrees/CrockPot/BBQSpareRibs.xml">Entrees / CrockPot: BBQ Spare Ribs</a></FinalNote>
 </Recipe>

--- a/Camping/Entrees/DO_DutchFathersPizza.xml
+++ b/Camping/Entrees/DO_DutchFathersPizza.xml
@@ -110,5 +110,5 @@
 		</note>
 	</Notes>
 
-	<FinalNote id="FinalNote">A similar recipe for use at home: <a href="../../Entrees/Oven/Pizza.xml">Entrees / Oven: Pizza</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for use at home: <a href=".../Entrees/Oven/Pizza.xml">Entrees / Oven: Pizza</a></FinalNote>
 </Recipe>

--- a/Camping/Entrees/DO_KlondikeChili.xml
+++ b/Camping/Entrees/DO_KlondikeChili.xml
@@ -15,7 +15,7 @@
 		month="4"
 		day="2" />
 
-	<Description id="Description">This is Ransom's second Chili recipe. The first one was really good, but it was complex and actually had to be started the day before you wanted to eat it. <span class="NOTE">(Additionally, most people found it to be too spicy.)</span> <span class="NOTE">(See <a href="../../Entrees/CrockPot/StealthAttackChili.xml">Entrees / CrockPot: Stealth-Attack Chili</a>.)</span> <br /> This recipe is geared towards quick preparation, and has actually won the first-place award at multiple Boy Scout district Dutch-oven chili cook-offs! </Description>
+	<Description id="Description">This is Ransom's second Chili recipe. The first one was really good, but it was complex and actually had to be started the day before you wanted to eat it. <span class="NOTE">(Additionally, most people found it to be too spicy.)</span> <span class="NOTE">(See <a href="../Entrees/CrockPot/StealthAttackChili.xml">Entrees / CrockPot: Stealth-Attack Chili</a>.)</span> <br /> This recipe is geared towards quick preparation, and has actually won the first-place award at multiple Boy Scout district Dutch-oven chili cook-offs! </Description>
 
 	<Ingredients id="Ingredients">
 		<section>
@@ -110,5 +110,5 @@
 		</modification>
 	</Modifications>
 
-	<FinalNote id="FinalNote">A similar recipe for use at home: <a href="../../Entrees/StoveTop/KlondikeChili.xml">Entrees / Stove Top: Klondike Chili</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for use at home: <a href=".../Entrees/StoveTop/KlondikeChili.xml">Entrees / Stove Top: Klondike Chili</a></FinalNote>
 </Recipe>

--- a/Canning/WildBlackberryJam.xml
+++ b/Canning/WildBlackberryJam.xml
@@ -39,7 +39,7 @@
 			<instruction>In a separate bowl, mix Sugar and Pectin.</instruction>
 			<instruction>When berry mixture is boiling, slowly mix in Sugar/Pectin mixture and stir until well dissolved.</instruction>
 			<instruction>Bring mixture to a boil again, and boil for 1 minute, then remove from heat immediately.</instruction>
-			<instruction>Follow instructions in the <a href="BathCanningHowTo.xml">Bath Canning: How-To</a> section.</instruction>
+			<instruction>Follow instructions in the <a href=".../Canning/BathCanningHowTo.xml">Bath Canning: How-To</a> section.</instruction>
 		</section>
 	</Instructions>
 	<Notes id="Description">

--- a/CookingBasics/Spices.html
+++ b/CookingBasics/Spices.html
@@ -1,4 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html lang="en">
 
 <head>
 	<title>VanOrman Family Recipes: Cooking Basics / Spices</title>

--- a/CookingBasics/Spices.xml
+++ b/CookingBasics/Spices.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../html.xsl"?>
+<!-- Include entities to be used in the xml -->
+<!DOCTYPE invoice [
+	<!ENTITY section SYSTEM "section.xml">
+	<!ENTITY page SYSTEM "Spices.html">
+	<!ENTITY % externalEntities SYSTEM "/entities.dtd">
+	%externalEntities;
+]>
+
+<HTML>
+	<Section>&section;</Section>
+	<LastModified year="2025"
+		month="4"
+		day="8" />
+
+	<!-- -->&page;<!-- -->
+</HTML>

--- a/CookingBasics/Substitutions.xml
+++ b/CookingBasics/Substitutions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../html.xsl"?>
+<!-- Include entities to be used in the xml -->
+<!DOCTYPE invoice [
+	<!ENTITY section SYSTEM "section.xml">
+	<!ENTITY page SYSTEM "Substitutions.html">
+	<!ENTITY % externalEntities SYSTEM "/entities.dtd">
+	%externalEntities;
+]>
+
+<HTML>
+	<Section>&section;</Section>
+	<LastModified year="2025"
+		month="4"
+		day="8" />
+
+	<!-- -->&page;<!-- -->
+</HTML>

--- a/CookingBasics/hold/Substitutions.html
+++ b/CookingBasics/hold/Substitutions.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 
 <head>
 	<title>VanOrman Family Recipes: Cooking Basics / Conversions and Substitutions</title>
@@ -302,7 +302,7 @@
 		<p>
 			Here's an example:
 			<br />
-			When I first did the <a href=".../Beverages/RootBeer.xml">Root Beer</a> recipe, I would buy the sugar specifically for the recipe.
+			When I first did the <a class="no-print" href="../Beverages/RootBeer.xml">Root Beer</a><span class="no-screen">Root Beer</span> recipe, I would buy the sugar specifically for the recipe.
 			That is one 10-lb. bag.
 			But later, I would buy my sugar 25 lbs. at a time.
 			That would make it so I always had what I needed on-hand and got it at a cheaper rate since I bought in bulk.
@@ -314,7 +314,7 @@
 		</p>
 		<p>
 			Another, more diverse example:
-			While I was a missionary in Puerto Rico, I once wanted to bake my favorite <a class="no-print" href=".../Desserts/RangerCookies.xml">Ranger Cookies</a><span class="no-screen">Ranger Cookies</span>.
+			While I was a missionary in Puerto Rico, I once wanted to bake my favorite <a class="no-print" href="../Desserts/RangerCookies.xml">Ranger Cookies</a><span class="no-screen">Ranger Cookies</span>.
 			Unfortunately, the recipe calls for Brown Sugar, and in my area it just wasn't to be found.
 			Well, regular Sugar works a lot like Brown Sugar, but it definitely doesn't taste the same.
 			I was able to find some really dark honey that was tangy like Brown Sugar, but wouldn't work the same. <i>(Who wants syrupy cookies?)</i>
@@ -360,6 +360,23 @@
 			<td>1 Cup Water + 1 Cube Chicken Bouillon</td>
 		</tr>
 	</table>
+
+	<div class="no-print">
+		<br />
+		<hr />
+		<table class="DIVIDER">
+			<tr>
+				<td>
+					<a href="/">Home</a>
+					/
+					<a href="..">Recipes</a>
+					/
+					<a class="no-print" href=".">Cooking Basics</a><span class="no-screen">Cooking Basics</span>
+				</td>
+				<td class="LAST_MODIFIED" style="text-align:right; vertical-align:top;">Last updated: 2025 March 07</td>
+			</tr>
+		</table>
+	</div>
 </body>
 
 </html>

--- a/CookingBasics/hold/Substitutions.xml
+++ b/CookingBasics/hold/Substitutions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../html.xsl"?>
+<!-- Include entities to be used in the xml -->
+<!DOCTYPE invoice [
+	<!ENTITY section SYSTEM "section.xml">
+	<!ENTITY page SYSTEM "Substitutions.html">
+	<!ENTITY % externalEntities SYSTEM "/entities.dtd">
+	%externalEntities;
+]>
+
+<HTML>
+	<title>HELLO</title>
+	<!--
+	<Section>&section;</Section>
+	<LastModified year="2025"
+		month="4"
+		day="8" />
+	-->
+
+	<!-- -->
+	<!-- &page; -->
+	<!-- -->
+</HTML>

--- a/CookingBasics/hold/html.xsl
+++ b/CookingBasics/hold/html.xsl
@@ -4,12 +4,9 @@
 
 	<xsl:include href="common.xsl" />
 
-	<!-- QZX TODO: Figure out a way to apply templates to .html pages. E.G. Create .xml that loads the document(.html) and applys templates to it.-->
-
-	<!-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ -->
-	<!-- @@@@@@@@@@@@@@@@@@@@                        Main Template                       @@@@@@@@@@@@@@@@@@@@ -->
-	<!-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ -->
-	<xsl:template match="Recipe">
+	<xsl:template match="HTML">
+		<xsl:value-of select="name()" />
+		<!--
 		<xsl:variable name="depth">
 			<xsl:choose>
 				<xsl:when test="document(concat(Section/section/@folder, '/section.xml'))/section/@folder = '.'">1</xsl:when>
@@ -24,6 +21,78 @@
 			</xsl:call-template>
 		</xsl:variable>
 
+		<html>
+			<head>
+				<title>FOO</title>
+			</head>
+			<body>
+				<!- - - ->BAR<!- - - -><br />
+				 <xml:value-of select="$depth" /><br />
+				 <xml:value-of select="$linkPrefix" /><br />
+				 <xml:value-of select="name()" />
+			</body>
+		</html>
+
+
+		<!- - <xsl:apply-templates select="html">
+			<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+		</xsl:apply-templates> - ->
+		-->
+	</xsl:template>
+
+	<!--
+	<xsl:template match="html">
+		<html>
+			<head></head>
+
+			<body>
+				FOO
+			</body>
+		</html>
+	</xsl:template>
+	-->
+
+	<!-- QZX TODO: Figure out a way to apply templates to .html pages. E.G. Create .xml that loads the document(.html) and applys templates to it.-->
+
+	<!-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ -->
+	<!-- @@@@@@@@@@@@@@@@@@@@                        Main Template                       @@@@@@@@@@@@@@@@@@@@ -->
+	<!-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ -->
+	<!--
+	<xsl:template match="HTML/html">
+		<xsl:variable name="depth">
+			<xsl:choose>
+				<xsl:when test="document(concat(Section/section/@folder, '/section.xml'))/section/@folder = '.'">1</xsl:when>
+				<xsl:when test="document(concat(Section/section/@folder, '/../section.xml'))/section/@folder = '.'">2</xsl:when>
+				<xsl:when test="document(concat(Section/section/@folder, '/../../section.xml'))/section/@folder = '.'">3</xsl:when>
+				<xsl:otherwise>0</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="linkPrefix">
+			<xsl:call-template name="LinkPrefix">
+				<xsl:with-param name="depth" select="$depth" />
+			</xsl:call-template>
+		</xsl:variable>
+
+		<xsl:apply-templates>
+			<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+		</xsl:apply-templates>
+
+	</xsl:template>
+
+	<xsl:template match="head">
+		<xsl:param name="linkPrefix" />
+
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="stylesheet" type="text/css" href="styles.css" />
+		<xsl:apply-templates>
+			<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+		</xsl:apply-templates>
+
+	</xsl:template>
+	-->
+
+
+	<!--
 		<html lang="en">
 			<head>
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -61,7 +130,7 @@
 								<td class="RECIPE_YIELDS" align="right">
 									<b>Yields</b>: <span>
 										<xsl:choose>
-											<!-- TODO QZX: Figure out how to <xsl:apply-templates ...> to the links below so that it doesn't look like a link when printing. -->
+											<!- - TODO QZX: Figure out how to <xsl:apply-templates ...> to the links below so that it doesn't look like a link when printing. - ->
 											<xsl:when test="@yields = 'See Ingredients'">
 												<xsl:attribute name="class">NOTE</xsl:attribute> (See <xsl:call-template name="section-link">
 													<xsl:with-param name="section" select="'Ingredients'" />
@@ -167,9 +236,9 @@
 
 	</xsl:template>
 
-	<!-- ************************************************************************************************************************ -->
-	<!--  Templates for sub-items                                                                                                 -->
-	<!-- ************************************************************************************************************************ -->
+	<!- - ************************************************************************************************************************ - ->
+	<!- -  Templates for sub-items                                                                                                 - ->
+	<!- - ************************************************************************************************************************ - ->
 	<xsl:template match="subSection">
 		<xsl:param name="linkPrefix" />
 
@@ -306,8 +375,8 @@
 					<div style="break-after:page;" />
 				</xsl:when>
 				<xsl:otherwise>
-					<!-- <span style="font-size:.25em;"> </span>
-				<br /> -->
+					<!- - <span style="font-size:.25em;"> </span>
+				<br /> - ->
 				</xsl:otherwise>
 			</xsl:choose>
 			<div class="SECTION_HEADER" id="Instructions">Instructions</div>
@@ -345,8 +414,8 @@
 						<div style="break-after:page;" />
 					</xsl:when>
 					<xsl:otherwise>
-						<!-- <span style="font-size:.25em;"> </span>
-					<br /> -->
+						<!- - <span style="font-size:.25em;"> </span>
+					<br /> - ->
 					</xsl:otherwise>
 				</xsl:choose>
 				<div class="SECTION_HEADER" id="Notes">Notes</div>
@@ -372,8 +441,8 @@
 						<div style="break-after:page;" />
 					</xsl:when>
 					<xsl:otherwise>
-						<!-- <span style="font-size:.25em;"> </span>
-					<br /> -->
+						<!- - <span style="font-size:.25em;"> </span>
+					<br /> - ->
 					</xsl:otherwise>
 				</xsl:choose>
 				<div class="SECTION_HEADER" id="AdditionalNotes">Additional Notes</div>
@@ -391,7 +460,7 @@
 
 		<xsl:if test="modification">
 			<div style="margin-top:.5em;">
-				<!-- <xsl:copy-of select="@*" /> -->
+				<!- - <xsl:copy-of select="@*" /> - ->
 				<xsl:choose>
 					<xsl:when test="@pageBreak">
 						<span class="no-screen">
@@ -400,8 +469,8 @@
 						<div style="break-after:page;" />
 					</xsl:when>
 					<xsl:otherwise>
-						<!-- <span style="font-size:.25em;"> </span>
-						<br /> -->
+						<!- - <span style="font-size:.25em;"> </span>
+						<br /> - ->
 					</xsl:otherwise>
 				</xsl:choose>
 				<div class="SECTION_HEADER" id="Modifications" style="">Modifications</div>
@@ -435,5 +504,5 @@
 			</xsl:apply-templates>
 		</li>
 	</xsl:template>
-
+	-->
 </xsl:stylesheet>

--- a/Desserts/Jigglers.xml
+++ b/Desserts/Jigglers.xml
@@ -57,5 +57,5 @@
 		</modification>
 	</Modifications>
 
-	<FinalNote id="FinalNote">A similar recipe for Diabetics is <a href="LS_GummyTreats.xml">Desserts and Snacks: Sugar-Free Gummy Treats</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for Diabetics is <a href=".../Desserts/LS_GummyTreats.xml">Desserts and Snacks: Sugar-Free Gummy Treats</a></FinalNote>
 </Recipe>

--- a/Desserts/RangerCookies.xml
+++ b/Desserts/RangerCookies.xml
@@ -56,6 +56,6 @@
 	</Notes>
 
 	<Modifications id="Modifications">
-		<modification>If you are somewhere where you have difficulty finding Brown Sugar <span class="NOTE">(which missionaries frequently have to deal with)</span> substitute 1 Cup Sugar and 1 Tablespoon Molasses or Dark Corn Syrup. <span class="NOTE">(See <a href="../CookingBasics/substitutions.html">Cooking Basics: Conversions and Substitutions</a> page.)</span></modification>
+		<modification>If you are somewhere where you have difficulty finding Brown Sugar <span class="NOTE">(which missionaries frequently have to deal with)</span> substitute 1 Cup Sugar and 1 Tablespoon Molasses or Dark Corn Syrup. <span class="NOTE">(See <a href=".../CookingBasics/substitutions.html">Cooking Basics: Conversions and Substitutions</a> page.)</span></modification>
 	</Modifications>
 </Recipe>

--- a/Entrees/CrockPot/BBQSpareRibs.xml
+++ b/Entrees/CrockPot/BBQSpareRibs.xml
@@ -55,5 +55,5 @@
 		<note>When serving the ribs, the extra sauce tastes wonderful over baked potatoes, with a dollop of sour cream.</note>
 	</Notes>
 
-	<FinalNote id="FinalNote">A similar recipe for Dutch Ovens: <a href="../../Camping/Entrees/DO_BBQSpareRibs.xml">Dutch Oven and other Camping Recipes: Dutch Oven BBQ Spare Ribs</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for Dutch Ovens: <a href=".../Camping/Entrees/DO_BBQSpareRibs.xml">Dutch Oven and other Camping Recipes: Dutch Oven BBQ Spare Ribs</a></FinalNote>
 </Recipe>

--- a/Entrees/CrockPot/CrockPotRoast.xml
+++ b/Entrees/CrockPot/CrockPotRoast.xml
@@ -68,6 +68,6 @@
 
 	<Modifications id="Modifications">
 		<modification>Instead of Lipton Onion Soup Mix, use Montreal Steak seasoning.</modification>
-		<modification>Use the broth to make <a href="../../SaucesAndDips/EasyGravy.xml">Sauces and Dips: Easy Gravy</a></modification>
+		<modification>Use the broth to make <a href=".../SaucesAndDips/EasyGravy.xml">Sauces and Dips: Easy Gravy</a></modification>
 	</Modifications>
 </Recipe>

--- a/Entrees/CrockPot/StealthAttackChili.xml
+++ b/Entrees/CrockPot/StealthAttackChili.xml
@@ -17,7 +17,7 @@
 		day="25" />
 
 	<Description id="Description"> This is one of the first recipes invented by Ransom. He wanted a good recipe that could be made with ingredients primarily from food storage. We went through several attempts, but once we succeeded, we would make it over and over. Due to the spices, it takes 4-5 bites before you realized it is very spicy hot. <span class="NOTE">(Thus stealth-attack.)</span>
-		<br /> Unfortunately, when we moved to Washington, nobody could stand how hot it was. <span class="NOTE">(It's not <span class="HIGHLIGHT">that</span> hot to me.)</span> And when made for Boy Scout competitions, it didn't have a good "look" to it, so we invented <a href="../StoveTop/KlondikeChili.xml">Entrees / Stove Top: Klondike Chili</a>. But, we still make this one from time to time. </Description>
+		<br /> Unfortunately, when we moved to Washington, nobody could stand how hot it was. <span class="NOTE">(It's not <span class="HIGHLIGHT">that</span> hot to me.)</span> And when made for Boy Scout competitions, it didn't have a good "look" to it, so we invented <a href=".../StoveTop/KlondikeChili.xml">Entrees / Stove Top: Klondike Chili</a>. But, we still make this one from time to time. </Description>
 
 	<Ingredients id="Ingredients">
 		<section>

--- a/Entrees/Oven/Pizza.xml
+++ b/Entrees/Oven/Pizza.xml
@@ -17,7 +17,7 @@
 		month="3"
 		day="27" />
 
-	<Description id="Description"> We have a family tradition of having home-made pizza every year on Halloween. This recipe is an adaptation of <a href="../../Camping/DO_DutchFathersPizza.xml">Dutch Oven and other Camping Recipes: Dutch Father's Pizza</a> that Grandpa John invented for Dutch ovens, but modified so we can cook it indoors. </Description>
+	<Description id="Description"> We have a family tradition of having home-made pizza every year on Halloween. This recipe is an adaptation of <a href=".../Camping/DO_DutchFathersPizza.xml">Dutch Oven and other Camping Recipes: Dutch Father's Pizza</a> that Grandpa John invented for Dutch ovens, but modified so we can cook it indoors. </Description>
 
 	<Ingredients id="Ingredients">
 		<section id="IngredientsCrust" title="Crust">
@@ -42,7 +42,7 @@
 			<ingredient name="Mushrooms" />
 			<ingredient name="Olives" />
 			<ingredient name="Tomatoes" nameNote="Sliced" />
-			<ingredient name="Pineapple" finePrint="Personally, Ransom thinks pineapple is a desecration on pizza, but his kids forced him to include it." />
+			<ingredient name="Pineapple" finePrint="Ransom thinks pineapple is a desecration on pizza, but his kids forced him to include it." />
 		</section>
 	</Ingredients>
 
@@ -59,7 +59,7 @@
 			<instruction>Put dough onto a cookie sheet.</instruction>
 			<instruction>Cookie sheet should either be greased or sprinkled with corn meal.</instruction>
 			<instruction>You can use a pie tin instead of a cookie sheet if you make them a little smaller.</instruction>
-			<instruction>Cover crust with sauce <span class="Note">(See recipe for <a href="../../Sauces/MarinaraSauce.xml">Sauces: Marinara Sauce</a>.)</span></instruction>
+			<instruction>Cover crust with sauce <span class="Note">(See recipe for <a href=".../Sauces/MarinaraSauce.xml">Sauces: Marinara Sauce</a>.)</span></instruction>
 			<instruction>
 				Add the toppings desired.
 				It usually works best to do a little cheese, then other ingredients, then more cheese.
@@ -71,7 +71,7 @@
 	</Instructions>
 
 	<Notes id="Notes">
-		<note>For Gluten Sensitive people, check out: <a href="GF_PizzaCrust.xml">Entrees / Oven: Gluten-Free Pizza Crust</a></note>
+		<note>For Gluten Sensitive people, check out: <a class="TODO qzxDisabled" href=".../Entrees/Oven/GF_PizzaCrust.xml">Entrees / Oven: Gluten-Free Pizza Crust</a></note>
 		<note>If time is short, you can just buy a simple spaghetti sauce to use for the pizza sauce, but if you do, don't get chunky sauce because it is hard to spread evenly over the crust.</note>
 		<note>Use left-over sauce as a dipping sauce for the pizza crusts.</note>
 	</Notes>

--- a/Entrees/StoveTop/KlondikeChili.xml
+++ b/Entrees/StoveTop/KlondikeChili.xml
@@ -17,7 +17,7 @@
 		month="3"
 		day="29" />
 
-	<Description id="Description"> This is Ransom's second Chili recipe. The first one, <a href="../CrockPot/StealthAttackChili.xml">Entrees / CrockPot: Stealth-Attack Chili</a>, was really good, but it was complex and actually had to be started the day before you wanted to eat it. On top of that, when we moved to Washington, nobody could handle it. &smiley; <br /> This recipe is geared towards quick preparation, and 7 out of 8 times it actually won the first-place award at a Boy Scout district Dutch-Oven Chili cook-off at Klondike Derbies! </Description>
+	<Description id="Description"> This is Ransom's second Chili recipe. The first one, <a href=".../CrockPot/StealthAttackChili.xml">Entrees / CrockPot: Stealth-Attack Chili</a>, was really good, but it was complex and actually had to be started the day before you wanted to eat it. On top of that, when we moved to Washington, nobody could handle it. &smiley; <br /> This recipe is geared towards quick preparation, and 7 out of 8 times it actually won the first-place award at a Boy Scout district Dutch-Oven Chili cook-off at Klondike Derbies! </Description>
 
 	<Ingredients id="Ingredients">
 		<section>
@@ -116,5 +116,5 @@
 		</modification>
 	</Modifications>
 
-	<FinalNote id="FinalNote">A similar recipe for use at home: <a href="../../Camping/DO_KlondikeChili.xml">Dutch Oven and other Camping Recipes: Dutch Oven Klondike Chili</a></FinalNote>
+	<FinalNote id="FinalNote">A similar recipe for use at home: <a href=".../Camping/DO_KlondikeChili.xml">Dutch Oven and other Camping Recipes: Dutch Oven Klondike Chili</a></FinalNote>
 </Recipe>

--- a/Entrees/StoveTop/WontonSoup.xml
+++ b/Entrees/StoveTop/WontonSoup.xml
@@ -50,7 +50,7 @@
 
 	<Instructions id="Instructions">
 		<section>
-			<instruction>If desired, get the Wontons by using the <a href="Wontons.xml">Entrees / Stove Top: Wontons</a> Recipe. <span class="NOTE">(Use the Envelope Style folding.)</span></instruction>
+			<instruction>If desired, get the Wontons by using the <a href=".../Entrees/StoveTop/Wontons.xml">Entrees / Stove Top: Wontons</a> Recipe. <span class="NOTE">(Use the Envelope Style folding.)</span></instruction>
 			<instruction>
 				Slice the Carrots into very thing discs.
 				Then lay the discs out flat and slice them into into strands.

--- a/common.xsl
+++ b/common.xsl
@@ -56,6 +56,21 @@
 			<xsl:value-of select="$section" />
 		</span>
 	</xsl:template>
+	<xsl:template name="LinkPrefix">
+		<xsl:param name="depth" />
+
+		<xsl:choose>
+			<xsl:when test="$depth > 1">
+				<xsl:value-of select="'../'" />
+				<xsl:call-template name="LinkPrefix">
+					<xsl:with-param name="depth" select="$depth - 1" />
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="'.'" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
 
 	<xsl:template match="a">
 		<xsl:param name="linkPrefix" />
@@ -85,7 +100,14 @@
 		In order to let "<xsl:apply-templates />" work, it is necessary to use this to copy standard HTML nodes and address their contents.
 		As new HTML elements are used in the Recipes, make sure to add them to this template.
 		- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-	<xsl:template match="blockquote|details|summary|br|div|hr|img|li|ol|p|span|table|td|th|tr|ul|b|i|u">
+	<xsl:template match="details|summary|
+		head|title|link|body|
+		blockquote|div|p|span|
+		br|hr|
+		img|
+		table|td|th|tr|
+		ul|ol|li|
+		b|i|u">
 		<xsl:param name="linkPrefix" />
 
 		<xsl:element name="{name()}">

--- a/html.xsl
+++ b/html.xsl
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:include href="common.xsl" />
+
+	<xsl:template match="HTML">
+		<xsl:variable name="depth">
+			<xsl:choose>
+				<xsl:when test="document(concat(Section/section/@folder, '/section.xml'))/section/@folder = '.'">1</xsl:when>
+				<xsl:when test="document(concat(Section/section/@folder, '/../section.xml'))/section/@folder = '.'">2</xsl:when>
+				<xsl:when test="document(concat(Section/section/@folder, '/../../section.xml'))/section/@folder = '.'">3</xsl:when>
+				<xsl:otherwise>0</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="linkPrefix">
+			<xsl:call-template name="LinkPrefix">
+				<xsl:with-param name="depth" select="$depth" />
+			</xsl:call-template>
+		</xsl:variable>
+
+		<!--
+		<xsl:apply-templates select="html">
+			<xsl:with-param name="linkPrefix" value="../boo" />
+		</xsl:apply-templates>
+		-->
+		<html>
+			<xsl:apply-templates select="html/head">
+				<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+			</xsl:apply-templates>
+
+			<body>
+				<div class="FLEX_CONTENT">
+					<xsl:apply-templates select="html/body/*">
+						<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+					</xsl:apply-templates>
+				</div>
+
+				<footer class="FLEX_FOOTER">
+					<table class="DIVIDER">
+						<tr>
+							<td class="no-print">
+								<a href="/">Home</a> / <xsl:choose>
+									<xsl:when test="ParentSection">
+										<a href="../..">Recipes</a> / <a href="..">
+											<xsl:value-of select="ParentSection" />
+										</a> / <a href=".">
+											<xsl:value-of select="Section" />
+										</a>
+									</xsl:when>
+									<xsl:otherwise>
+										<a href="..">Recipes</a> / <a href=".">
+											<xsl:value-of select="Section" />
+										</a>
+									</xsl:otherwise>
+								</xsl:choose>
+							</td>
+							<td class="LAST_MODIFIED" style="text-align:right;"> Last updated: <xsl:apply-templates select="LastModified" />
+							</td>
+						</tr>
+					</table>
+				</footer>
+			</body>
+		</html>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/index.xsl
+++ b/index.xsl
@@ -52,20 +52,14 @@
 						<tr>
 							<td class="no-print">
 								<a href="/">Home</a>
-								<xsl:choose>
-									<xsl:when test="ParentSection">
-										<b> / </b>
-										<a href="../..">Recipes</a>
-										<b> / </b>
-										<a href="..">
-											<xsl:copy-of select="ParentSection/section/text()|ParentSection/section/*" />
-										</a>
-									</xsl:when>
-									<xsl:otherwise>
-										<b> / </b>
-										<a href="..">Recipes</a>
-									</xsl:otherwise>
-								</xsl:choose>
+								<b> / </b>
+								<a><xsl:attribute name="href" select="concat($linkPrefix, '/Recipes'" /> Recipes </a>
+								<xsl:if test="ParentSection">
+									<b> / </b>
+									<a href="..">
+										<xsl:copy-of select="ParentSection/section/text()|ParentSection/section/*" />
+									</a>
+								</xsl:if>
 							</td>
 							<td class="LAST_MODIFIED" style="text-align:right;"> Last updated: <xsl:apply-templates select="LastModified" />
 							</td>
@@ -78,22 +72,6 @@
 			</body>
 		</html>
 
-	</xsl:template>
-
-	<xsl:template name="LinkPrefix">
-		<xsl:param name="depth" />
-
-		<xsl:choose>
-			<xsl:when test="$depth > 1">
-				<xsl:value-of select="'../'" />
-				<xsl:call-template name="LinkPrefix">
-					<xsl:with-param name="depth" select="$depth - 1" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="'.'" />
-			</xsl:otherwise>
-		</xsl:choose>
 	</xsl:template>
 
 	<!-- ************************************************************************************************************************ -->


### PR DESCRIPTION
When creating links to sub-pages, the relative path ends up only working at 1 depth.
Make it so the prefix ".../" means the root of the Recipes section.

.html files need to be able to be transformed to handle paths, etc.
To handle this, a wrapper <page>.xml needs to be created.
The the .html page needs to:
-  remove the xmlns attribute in the <html> node.
- Remove the footer at the bottom of the HTML
- Update any links in the document so there isn't a class="no-print"/class="no-screen".