### PR TITLE
Apply Templates to Recipe Description

### DIFF
--- a/recipe.xsl
+++ b/recipe.xsl
@@ -105,7 +105,9 @@
 						</tr>
 						<tr>
 							<td class="DESCRIPTION" colspan="2" style="padding-top:.5em;">
-								<xsl:copy-of select="Description" />
+								<xsl:apply-templates select="Description">
+									<xsl:with-param name="linkPrefix" select="$linkPrefix" />
+								</xsl:apply-templates>
 							</td>
 						</tr>
 					</table>


### PR DESCRIPTION
If there are links in the Description for a Recipe, the path is incorrect.
To make it correct, apply-templates needs to be performed on the Description.
